### PR TITLE
Fix HTML tag order

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -10,7 +10,7 @@
 	  {{ end }}
       <div class="e-content">{{ .Content }}</div>
       <footer class="post__footer">
-        <small><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}"><a href="{{ .Permalink }}" title="Permalink to Microblog post" class="u-url">{{ .Date.Format "Mon, Jan 2, 2006 at 3:04pm" }}</time></a></small>
+        <small><a href="{{ .Permalink }}" title="Permalink to Microblog post" class="u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ .Date.Format "Mon, Jan 2, 2006 at 3:04pm" }}</time></a></small>
       </footer>
     </article>
 


### PR DESCRIPTION
The `<time>` parent element was closed before the `<a>` child  element.
This fix wraps `<time>` inside `<a>`.