### PR TITLE
Use .Pages instead of .Site.Pages

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <section class="posts h-feed">
 
-{{ $paginator := .Paginate (where .Site.Pages.ByDate.Reverse "Type" "post") (index .Site.Params "archive-paginate" | default 25) }}
+{{ $paginator := .Paginate (where .Pages.ByDate.Reverse "Type" "post") (index .Site.Params "archive-paginate" | default 25) }}
 {{ range $paginator.Pages  }}
 
     <article class="post h-entry">


### PR DESCRIPTION
This makes sure the layout works for category pages and fixes the bug reported [at the Help Center](https://help.micro.blog/t/primrose-theme-redirects-category-pages-and-hugo-compatibility/1054/10).