### PR TITLE
Add special case for homepage

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <section class="posts h-feed">
 
-{{ $paginator := .Paginate (where .Pages.ByDate.Reverse "Type" "post") (index .Site.Params "archive-paginate" | default 25) }}
+{{ $paginator := .Paginate (where (cond .IsHome .Site.Pages .Pages).ByDate.Reverse "Type" "post") (index .Site.Params "archive-paginate" | default 25) }}
 {{ range $paginator.Pages  }}
 
     <article class="post h-entry">


### PR DESCRIPTION
Use `.Site.Pages` for homepage. Thanks for [the hint](https://github.com/microdotblog/theme-primrose/pull/4#issuecomment-1881209690), @manton. I haven't investigated further either, but you're right. This commit uses the `cond` function to handle the homepage separately. Tested on Hugo 0.117 and 0.91.